### PR TITLE
Flush asynchronously

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.IO.StreamWriter/CS/example24.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.IO.StreamWriter/CS/example24.cs
@@ -19,6 +19,7 @@ namespace ConsoleApplication
             using (StreamWriter writer = File.CreateText("newfile.txt"))
             {
                 await writer.WriteAsync(charsToAdd, 0, charsToAdd.Length);
+                await writer.FlushAsync();
             }
         }
     }


### PR DESCRIPTION
If you don't call `FlushAsync` and `WriteAsync` doesn't happen to do a flush for you, then when the using statement calls `Dispose`, it will do a blocking flush, which defeats the purpose of async.

Other samples should be updated accordingly.